### PR TITLE
URL sniffing for enable forks to view their forks github pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+developer.docs.joomla.org


### PR DESCRIPTION
Adds the URL sniffing to add in the repo name if the URL is not the official Joomla docs URL.

Removes  CNAME to enable testing on the forked repo before reverting the changes so this PR can be issued without messing up the official repo.

There should be a cleaner way of handling this, or a note should be added so that forkers know why they can't view their changes.
